### PR TITLE
Implemented track LOD

### DIFF
--- a/src/Engine/Renderables/CurvedSegment.h
+++ b/src/Engine/Renderables/CurvedSegment.h
@@ -59,7 +59,7 @@ namespace Engine
 		* Render track spokes, should be rendered together with a track
 		* @param spokeLength length of spoke horizontally so this should be around the same length as trackwidth
 		* @param spokesDistance amount of spokes rendered should probably be based on length returned from rendertrack
-		* @param segments
+		* @param segments base amount of segments to use setting this too low can cause wrong length calculation
 		*/
 		static void RenderTrackSpokesWorldPos( const Camera& camera, Surface& drawSurface, const float2& lStart, const float2& lStartDir, const float2& lEnd, const float2& lEndDir, float hardness, uint color, float spokeLength, float spokeWidth, float spokesDistance, uint segments, float wobblyness = 5.f, CurveSetupMode setupMode = CurveSetupMode::LongestBend );
 

--- a/vendor/template/common.h
+++ b/vendor/template/common.h
@@ -13,6 +13,16 @@ constexpr int SCRHEIGHT = 720;
 constexpr float ASPECT_RATIO = static_cast<float>(SCRWIDTH) / static_cast<float>(SCRHEIGHT);
 // #define FULLSCREEN
 
+constexpr float BASE_TRACK_LOD = 0.035f; // Base (sub)segments per distance for tracks
+constexpr float BASE_SPOKE_LOD = 0.1f; // Base (sub)segments per distance for track spokes, should be higher than track lod
+constexpr uint MIN_SPOKE_LOD = 7u; // If spokes get bellow this LOD they stop drawing should be > 0
+constexpr uint MAX_LOD = 100u;
+
+
+
+
+
+
 // constants
 #define PI			3.14159265358979323846264f
 #define INVPI		0.31830988618379067153777f


### PR DESCRIPTION
LOD based on camera zoom and track length.
Uses subsegments to draw track, which means that base segment count of tracks should be way lower i.e around 2-4 because that is still used for length calculation
![Game_debug_3SiZE4OKkP](https://github.com/user-attachments/assets/dc31a7e1-5ec3-466c-af30-583b6264370c)
