### PR TITLE
Build mode now requires control for zooming, default doesnt issue #20

### DIFF
--- a/src/Engine/Camera/Camera.cpp
+++ b/src/Engine/Camera/Camera.cpp
@@ -37,7 +37,7 @@ void Engine::Camera::Update( const float deltaTime )
 	}
 
 	// Zooming
-	if (input.IsKeyDown(GLFW_KEY_LEFT_CONTROL))
+	if (input.IsKeyDown(GLFW_KEY_LEFT_CONTROL) || !m_buildModeCamera)
 	{
 		float zoomDir = 1.f;
 		zoomDir += input.GetScrollDelta() * deltaTime * m_scrollSensitivity;

--- a/src/Engine/Camera/Camera.h
+++ b/src/Engine/Camera/Camera.h
@@ -27,17 +27,19 @@ namespace Engine
 		[[nodiscard]] float2 GetCameraPosition( const float2& worldPosition ) const;
 		[[nodiscard]] float2 GetWorldPosition( const float2& localPosition ) const;
 
+		void SetBuildMode( const bool value ) { m_buildModeCamera = value; }
+
 	private:
 		float2 m_position{0.f, 0.f};
-
+		float2 m_lockedWorldMousePos{};
 		int2 m_resolution;
 		float m_wishWidthSize;
 
 		float m_scrollSensitivity = 10.0f;
-		float m_scrollMouseImpact = 2.f;
 		float m_moveSpeed = 150.0f;
 
-		float2 m_lockedWorldMousePos{};
 		bool m_mouseLocked{false};
+
+		bool m_buildModeCamera{false};
 	};
 }

--- a/src/Engine/World/World.cpp
+++ b/src/Engine/World/World.cpp
@@ -9,9 +9,7 @@
 #include "Game/Trains/Wagon.h"
 #include "Game/Buildings/Building.h"
 #include "Game/Trains/Train.h"
-#include "Game/TrainSystem/Partials/TrackWalkerVisualizer.h"
 #include "Game/TrainSystem/TrainWalker/TrackWalker.h"
-#include "Renderables/CurvedSegment.h"
 #include "UI/UIManager.h"
 
 Engine::World::~World()
@@ -73,7 +71,6 @@ void Engine::World::Update( float deltaTime )
 	m_particles.Update(deltaTime);
 
 	//m_trackDebugger.Update(m_camera);
-
 
 	// Render pass
 	m_grid.Render(m_camera, *m_renderTarget);

--- a/src/Game/TrainSystem/TrackBuilder.cpp
+++ b/src/Game/TrainSystem/TrackBuilder.cpp
@@ -16,7 +16,7 @@ void TrackBuilder::Init( TrackManager* trackManager, TrackRenderer* trackRendere
 	m_trackRenderer = trackRenderer;
 }
 
-void TrackBuilder::Update( const Engine::Camera& camera, [[maybe_unused]] float deltaTime )
+void TrackBuilder::Update( Engine::Camera& camera, [[maybe_unused]] float deltaTime )
 {
 	const Engine::InputManager& input = Input::get();
 
@@ -24,6 +24,7 @@ void TrackBuilder::Update( const Engine::Camera& camera, [[maybe_unused]] float 
 	{
 		if (input.IsKeyJustDown(GLFW_KEY_B))
 		{
+			camera.SetBuildMode(true);
 			m_currentProgress = BuildProgress::Start;
 		}
 		return;
@@ -31,6 +32,7 @@ void TrackBuilder::Update( const Engine::Camera& camera, [[maybe_unused]] float 
 
 	if (input.IsKeyJustDown(GLFW_KEY_B) || input.IsKeyJustDown(GLFW_KEY_ESCAPE))
 	{
+		camera.SetBuildMode(false);
 		m_currentProgress = BuildProgress::NoBuild;
 		return;
 	}

--- a/src/Game/TrainSystem/TrackBuilder.h
+++ b/src/Game/TrainSystem/TrackBuilder.h
@@ -22,7 +22,7 @@ public:
 
 	void Init( TrackManager* trackManager, TrackRenderer* trackRenderer );
 
-	void Update( const Engine::Camera& camera, float deltaTime );
+	void Update( Engine::Camera& camera, float deltaTime );
 
 	void Render( const Engine::Camera& camera, Surface& renderTarget ) const;
 


### PR DESCRIPTION
Now you need to change state within the camera to set the zooming behavior.

Might need to rethink how we handle inputs, if we see that there are more edge cases like this.
Because I do not really like that this is in the camera..